### PR TITLE
Initial Deploy and Prepare scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ description = "Kiwix Hotspot Demo"
 readme = "README.md"
 dependencies = [
     "requests==2.31.0",
-    "Jinja2==3.1.3"
+    "Jinja2==3.1.3",
+    "pyyaml==6.0.1"
 ]
 dynamic = ["authors", "classifiers", "keywords", "license", "version", "urls"]
 

--- a/src/offspot_demo/__about__.py
+++ b/src/offspot_demo/__about__.py
@@ -1,1 +1,2 @@
+NAME = "demo"
 __version__ = "0.1.0-dev0"

--- a/src/offspot_demo/constants.py
+++ b/src/offspot_demo/constants.py
@@ -5,13 +5,12 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from offspot_demo.__about__ import NAME as PROJECT_NAME
+from offspot_demo.__about__ import NAME
 
 OFFSPOT_IMAGE_ID = "offspot-demo"
 OFFSPOT_IMAGE_URL = f"https://api.imager.kiwix.org/auto-images/{OFFSPOT_IMAGE_ID}/json"
 TARGET_DIR = Path(os.getenv("TARGET_DIR", "/data"))
 IMAGE_PATH = Path(os.getenv("IMAGE_PATH", "/demo/image.img"))
-PREPARED_FLAG_PATH = TARGET_DIR / "prepared.ok"
 
 FQDN = os.getenv("OFFSPOT_DEMO_FQDN", "demo.hostpot.kiwix.org")
 
@@ -38,6 +37,8 @@ STARTUP_DURATION = 10
 # in order not to be purged by deploy
 DOCKER_LABEL_MAINT = "maintenance"
 
+OCI_PLATFORM = os.getenv("OCI_PLATFORM", "linux/amd64")
+
 
 class Mode(enum.Enum):
     IMAGE = 1
@@ -45,7 +46,4 @@ class Mode(enum.Enum):
 
 
 logging.basicConfig(level=logging.INFO)
-
-
-def get_logger(name: str | None) -> logging.Logger:
-    return logging.getLogger(PROJECT_NAME if not name else f"{PROJECT_NAME}/{name}")
+logger = logging.getLogger(NAME)

--- a/src/offspot_demo/constants.py
+++ b/src/offspot_demo/constants.py
@@ -5,9 +5,8 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 OFFSPOT_IMAGE_ID = "offspot-demo"
 OFFSPOT_IMAGE_URL = f"https://api.imager.kiwix.org/auto-images/{OFFSPOT_IMAGE_ID}/json"
-
-TARGET_DIR = Path("/host/data")
-IMAGE_PATH = Path("/host/demo/image.img")
+TARGET_DIR = Path(os.getenv("TARGET_DIR", "/data"))
+IMAGE_PATH = Path(os.getenv("IMAGE_PATH", "/demo/image.img"))
 PREPARED_FLAG_PATH = TARGET_DIR / "prepared.ok"
 
 FQDN = os.getenv("OFFSPOT_DEMO_FQDN", "demo.hostpot.kiwix.org")
@@ -30,3 +29,7 @@ JINJA_ENV = Environment(
 # Expected duration for the service startup ; scripts use this to pause and check that
 # service is still up after this duration
 STARTUP_DURATION = 10
+
+# maintenance container and images must be labeled with this
+# in order not to be purged by deploy
+DOCKER_LABEL_MAINT = "maintenance"

--- a/src/offspot_demo/constants.py
+++ b/src/offspot_demo/constants.py
@@ -1,3 +1,4 @@
+import enum
 import logging
 import os
 from pathlib import Path
@@ -36,6 +37,11 @@ STARTUP_DURATION = 10
 # maintenance container and images must be labeled with this
 # in order not to be purged by deploy
 DOCKER_LABEL_MAINT = "maintenance"
+
+
+class Mode(enum.Enum):
+    IMAGE = 1
+    MAINT = 2
 
 
 logging.basicConfig(level=logging.INFO)

--- a/src/offspot_demo/constants.py
+++ b/src/offspot_demo/constants.py
@@ -1,7 +1,10 @@
+import logging
 import os
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from offspot_demo.__about__ import NAME as PROJECT_NAME
 
 OFFSPOT_IMAGE_ID = "offspot-demo"
 OFFSPOT_IMAGE_URL = f"https://api.imager.kiwix.org/auto-images/{OFFSPOT_IMAGE_ID}/json"
@@ -33,3 +36,10 @@ STARTUP_DURATION = 10
 # maintenance container and images must be labeled with this
 # in order not to be purged by deploy
 DOCKER_LABEL_MAINT = "maintenance"
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def get_logger(name: str | None) -> logging.Logger:
+    return logging.getLogger(PROJECT_NAME if not name else f"{PROJECT_NAME}/{name}")

--- a/src/offspot_demo/deploy.py
+++ b/src/offspot_demo/deploy.py
@@ -1,2 +1,317 @@
+""" Deploy an image from an image URL
+
+Limitations:
+- URL must be hosted on S3 (or at least webserver must serve an md5 digest in ETag)
+- Image must be Imager-service-created: have its data in a 3rd ext4 partition
+"""
+
+import argparse
+import hashlib
+import http
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import NamedTuple
+
+import requests
+
+from offspot_demo.__about__ import __version__
+from offspot_demo.constants import (
+    DOCKER_LABEL_MAINT,
+    IMAGE_PATH,
+    TARGET_DIR,
+)
+from offspot_demo.prepare import prepare_image
+from offspot_demo.toggle import toggle_demo
+from offspot_demo.utils.image import (
+    attach_to_device,
+    detach_device,
+    get_loopdev,
+    get_loopdev_used_by,
+    is_mounted,
+    mount_on,
+    unmount,
+)
+
+ONE_MIB = 2**20
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("demo-deploy")
+
+
+def fail(message: str = "An error occured", code: int = 1) -> int:
+    logger.error(message)
+    return code
+
+
+def is_url_correct(url: str) -> bool:
+    """whether URL is reachable"""
+    with requests.get(url, timeout=5, stream=True) as resp:
+        return resp.status_code == http.HTTPStatus.OK
+
+
+def prune_docker():
+    """Remove all containers and images not associated with maintenance mode"""
+    # purge all containers except maint-labeled ones
+    if subprocess.run(
+        [
+            "/usr/bin/docker",
+            "container",
+            "prune",
+            "--force",
+            "--filter",
+            f"label!={DOCKER_LABEL_MAINT}",
+        ],
+        check=False,
+    ).returncode:
+        logger.warning("Failed to prune containers")
+
+    # purge all containers except maint-labeled ones
+    if subprocess.run(
+        [
+            "/usr/bin/docker",
+            "image",
+            "prune",
+            "--force",
+            "--filter",
+            f"label!={DOCKER_LABEL_MAINT}",
+        ],
+        check=False,
+    ).returncode:
+        logger.warning("Failed to prune images")
+
+
+class S3CompatibleETag(NamedTuple):
+    """Checksum informations from ETag HTTP header on an S3 host
+
+    S3 always sends an ETag which is either the MD5 checksum for single-part files
+    or a checksum of all the parts individual checksums for multi-part files.
+
+    Single or multiple part is based on how it was uploaded and the part size is not
+    standard but is generally rounded to a MiB.
+
+    Storing all required information in this object to be able to re-compute the final
+    checksum and ETag using the downloaded file"""
+
+    checksum: str
+    nb_parts: int
+    parts_size: int
+    filesize: int
+
+    @property
+    def etag(self):
+        return f"{self.checksum}-{self.nb_parts}"
+
+    @property
+    def found(self):
+        return self.nb_parts >= 1
+
+    @property
+    def is_multipart(self) -> bool:
+        return self.found and self.nb_parts > 1
+
+    @property
+    def is_singlepart(self):
+        return self.nb_parts == 1
+
+
+def get_checksum_from(url: str) -> S3CompatibleETag:
+    """S3CompatibleETag from a URL
+
+    Should the URL not return an ETag or Content-Length, it is assumed to not
+    have a checksum."""
+
+    with requests.get(url, timeout=5, stream=True) as resp:
+        size = resp.headers.get("Content-Length")
+        etag = resp.headers.get("ETag", "").replace('"', "").replace("'", "")
+    if not size or not etag:
+        return S3CompatibleETag("", 0, 0, 0)
+
+    size = int(size)
+
+    # single part etag
+    if "-" not in etag:
+        return S3CompatibleETag(etag, 1, size, size)
+
+    digest, nb_parts = etag.split("-", 1)
+    nb_parts = int(nb_parts)
+
+    size_in_mib = size // ONE_MIB
+    if size_in_mib % nb_parts != 0:
+        parts_size = size // (nb_parts - 1)
+    else:
+        parts_size = size // nb_parts
+    # round to MiB
+    parts_size = parts_size // ONE_MIB * ONE_MIB
+
+    return S3CompatibleETag(digest, nb_parts, parts_size, size)
+
+
+def compute_s3etag_for(fpath: Path, digest: S3CompatibleETag):
+    """Compute-back an S3 multipart ETag using local file and info from orig ETag"""
+    concat_sum = b""
+    with open(fpath, "rb") as fh:
+        for _ in range(digest.nb_parts):
+            sum_ = hashlib.md5(fh.read(digest.parts_size), usedforsecurity=False)
+            concat_sum += sum_.digest()
+    concat_hex = hashlib.md5(concat_sum, usedforsecurity=False).hexdigest()
+    return f"{concat_hex}-{digest.nb_parts}"
+
+
+def download_file_into(url: str, dest: Path, digest: S3CompatibleETag) -> int:
+    """Download url into dest using aria2c, validating checksum"""
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    # download into a temp folder next to target
+    with TemporaryDirectory(
+        suffix=".aria2", dir=dest.parent, ignore_cleanup_errors=True, delete=True
+    ) as tmpdir:
+        tmp_dest = Path(tmpdir).joinpath("image.img")
+
+        args = ["aria2c", "--dir", str(tmp_dest.parent), "--out", "image.img"]
+        # single part checksum, let aria2 handle checksum validation
+        if digest.is_singlepart:
+            args += ["--checksum", digest.checksum]
+        args += [url]
+        aria2 = subprocess.run(args, check=False)
+
+        if aria2.returncode != 0:
+            logger.error("Failed to download with aria2c: {aria2.returncode}")
+            return aria2.returncode
+
+        if digest.is_multipart:
+            logger.info(">> verify checksum…")
+
+            computed = compute_s3etag_for(fpath=tmp_dest, digest=digest)
+            if computed != digest.etag:
+                logger.error(
+                    f"MD5 checksum validation failed: {computed=} != {digest.etag}"
+                )
+                return 32
+        # move to destination (should be safe as we're in sub of parent)
+        tmp_dest.rename(dest)
+
+    logger.info("Download completed")
+    return 0
+
+
+def deploy_url(url: str, *, reuse_image: bool):
+    """Deploy from an URL
+
+    Parameters:
+        reuse_image: whether to not remove existing image file and skip download (dev)
+    """
+    logger.info(f"deploying for {url}")
+
+    if not is_url_correct(url):
+        return fail(f"URL is incorrect: {url}")
+    logger.info("> URL is OK")
+
+    rc = toggle_demo(mode="maintenance")
+    if rc:
+        return fail("Failed to switch to maintenance mode")
+
+    if is_mounted(TARGET_DIR):
+        logger.info(f"> unmounting {TARGET_DIR}")
+        if not unmount(TARGET_DIR):
+            return fail(f"Failed to unmout {TARGET_DIR}")
+
+    loop_dev = get_loopdev_used_by(IMAGE_PATH)
+    if loop_dev:
+        logger.info(f"> detaching {loop_dev}")
+        if not detach_device(loop_dev=loop_dev, failsafe=True):
+            return fail(f"Failed to detach {loop_dev}")
+
+    if IMAGE_PATH.exists() and not reuse_image:
+        logger.info(f"> removing {IMAGE_PATH}")
+        try:
+            IMAGE_PATH.unlink(missing_ok=True)  # should not be missing
+        except Exception as exc:
+            logger.exception(exc)
+            return fail(f"Failed to remove {IMAGE_PATH}: {exc}")
+
+    logger.info("> purging docker")
+    prune_docker()
+
+    logger.info("Download image file using aria2")
+    if not reuse_image:
+        rc = download_file_into(url=url, dest=IMAGE_PATH, digest=get_checksum_from(url))
+        if rc:
+            return fail("Failed to download image", rc)
+
+    logger.info("Requesting loop device")
+    try:
+        loop_dev = get_loopdev()
+    except Exception as exc:
+        logger.exception(exc)
+        return fail("Failed to get loop-devices (all slots taken?)")
+    logger.info(f"> {loop_dev}")
+
+    logger.info(f"Attaching image to {loop_dev}")
+    try:
+        attach_to_device(img_fpath=IMAGE_PATH, loop_dev=loop_dev)
+    except Exception as exc:
+        logger.debug(exc)
+        return fail(f"Failed to attach image to {loop_dev}: {exc}")
+
+    TARGET_DIR.mkdir(parents=True, exist_ok=True)
+
+    logger.info(f"Mounting 3rd partition to {TARGET_DIR}")
+    if not mount_on(
+        dev_path=f"{loop_dev}p3", mount_point=TARGET_DIR, filesystem="ext4"
+    ):
+        return fail(f"Failed to mount {loop_dev}p3 to TARGET_DIR")
+
+    rc = prepare_image(target_dir=TARGET_DIR)
+    if rc:
+        return fail("Failed to prepare image", rc)
+
+    logger.info("Switching to image mode")
+    rc = toggle_demo(mode="image")
+    if rc:
+        return fail("Failed to switch to image mode", rc)
+
+    logger.info("> demo ready")
+    return 0
+
+
 def entrypoint():
-    print("Hello from deploy")
+    parser = argparse.ArgumentParser(
+        prog="demo-deploy", description="Deploy an offspot demo from an Image URL"
+    )
+
+    parser.add_argument("-D", "--debug", action="store_true", dest="debug")
+    parser.add_argument("-V", "--version", action="version", version=__version__)
+
+    parser.add_argument(
+        "--reuse-image",
+        action="store_true",
+        dest="reuse_image",
+        default=False,
+        help="[dev] reuse already downloaded image instead of downloading",
+    )
+
+    parser.add_argument(
+        dest="url",
+        help="Imager Service-created Image URL",
+    )
+
+    # kwargs = dict(parser.parse_args()._get_kwargs())
+    args = parser.parse_args()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    try:
+        sys.exit(deploy_url(url=args.url, reuse_image=args.reuse_image))
+    except Exception as exc:
+        if args.debug:
+            logger.exception(exc)
+        logger.critical(str(exc))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(entrypoint())

--- a/src/offspot_demo/deploy.py
+++ b/src/offspot_demo/deploy.py
@@ -22,6 +22,7 @@ from offspot_demo.constants import (
     DOCKER_LABEL_MAINT,
     IMAGE_PATH,
     TARGET_DIR,
+    get_logger,
 )
 from offspot_demo.prepare import prepare_image
 from offspot_demo.toggle import toggle_demo
@@ -37,8 +38,7 @@ from offspot_demo.utils.image import (
 
 ONE_MIB = 2**20
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("demo-deploy")
+logger = get_logger("deploy")
 
 
 def fail(message: str = "An error occured", code: int = 1) -> int:

--- a/src/offspot_demo/prepare.py
+++ b/src/offspot_demo/prepare.py
@@ -14,7 +14,7 @@ except ImportError:
     from yaml import Dumper, SafeLoader
 
 from offspot_demo.constants import FQDN, OCI_PLATFORM, TARGET_DIR, logger
-from offspot_demo.utils import fail
+from offspot_demo.utils import fail, is_root
 from offspot_demo.utils.process import run_command
 
 
@@ -54,6 +54,9 @@ def prepare_image(target_dir: Path) -> int:
         target_dir: the path of a mounted 3rd partition or an offspot image
     """
     logger.info(f"prepare-image from {target_dir!s}")
+
+    if not is_root():
+        return fail("must be root", 1)
 
     preapred_ok_path = target_dir / "prepared.ok"
     if preapred_ok_path.exists():

--- a/src/offspot_demo/prepare.py
+++ b/src/offspot_demo/prepare.py
@@ -1,10 +1,201 @@
+import argparse
+import logging
+import sys
 from pathlib import Path
+from typing import Any
+
+import yaml
+
+try:
+    from yaml import CDumper as Dumper
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    # we don't NEED cython ext but it's faster so use it if avail.
+    from yaml import Dumper, SafeLoader
+
+from offspot_demo.constants import FQDN, OCI_PLATFORM, TARGET_DIR, logger
+from offspot_demo.utils import fail
+from offspot_demo.utils.process import run_command
 
 
-def entrypoint():
-    print("Hello from prepare")
+def docker_pull(ident: str) -> int:
+    """pull a docker image via docker CLI"""
+
+    # should we validate `ident` first? As it comes from an external file
+    # and we pass it to subprocess…
+    return (
+        run_command(
+            [
+                "docker",
+                "image",
+                "pull",
+                "--platform",
+                OCI_PLATFORM,
+                ident,
+            ]
+        ).returncode
+        == 0
+    )
+
+
+def yaml_dump(data: dict[str, Any]) -> str:
+    """YAML textual representation of data"""
+    return yaml.dump(data, Dumper=Dumper, explicit_start=True, sort_keys=False)
+
+
+def yaml_load(data: str) -> dict[str, Any]:
+    return yaml.load(data, Loader=SafeLoader)
 
 
 def prepare_image(target_dir: Path) -> int:
-    print(f"prepare-image {target_dir=}")
-    return 1
+    """Prepare a deployment from a mounted image path
+
+    Parameters:
+        target_dir: the path of a mounted 3rd partition or an offspot image
+    """
+    logger.info(f"prepare-image from {target_dir!s}")
+
+    preapred_ok_path = target_dir / "prepared.ok"
+    if preapred_ok_path.exists():
+        return 0
+
+    dashboard_path = target_dir / "contents" / "dashboard.yaml"
+    image_yaml_path = target_dir / "image.yaml"
+
+    for fpath in (image_yaml_path, dashboard_path):
+        if not fpath.exists():
+            return fail(
+                f"Missing {fpath.relative_to(target_dir)} YAML. "  # noqa: ISC003
+                + f"Not an Imager Service image? -- {fpath}",
+                1,
+            )
+
+    # read and parse /data/contents/dashboard.yaml
+    dashboard = yaml_load(dashboard_path.read_text())
+
+    # record original FQDN as we'll need it for replaces
+    orig_fqdn = str(dashboard["metadata"]["fqdn"])
+
+    # update FQDN
+    dashboard["metadata"]["fqdn"] = FQDN
+
+    # update all entries' urls
+    for entry in dashboard.get("packages", []):
+        if entry.get("url"):
+            entry["url"] = entry["url"].replace(orig_fqdn, FQDN)
+        if entry.get("download", {}).get("url"):
+            entry["download"]["url"] = entry["download"]["url"].replace(orig_fqdn, FQDN)
+
+    for reader in dashboard.get("readers", []):
+        if reader.get("download_url"):
+            reader["download_url"] = reader["download_url"].replace(orig_fqdn, FQDN)
+
+    for link in dashboard.get("links", []):
+        if link.get("url"):
+            link["url"] = link["url"].replace(orig_fqdn, FQDN)
+
+    # overwrite file
+    dashboard_path.write_text(yaml_dump(dashboard))
+
+    image_yaml = yaml_load(image_yaml_path.read_text())
+    compose = image_yaml.get("offspot", {}).get("containers")
+    if not compose:
+        return fail("Missing compose definition in image.yaml (offspor.containers)", 1)
+
+    offspot_root = Path("/data")
+
+    for svcname, service in compose.get("services", {}).items():
+
+        for volume in service.get("volumes", []):
+            # we accept /data prefixed sources
+            if Path(volume["source"]).is_relative_to(offspot_root):
+                # rewrite so it works off any `target_dir` but shouldnt be necessary
+                # on prod if we use `/data` as well
+                volume["source"] = str(
+                    target_dir / Path(volume["source"]).relative_to(offspot_root)
+                )
+                continue
+            # reverse-proxy only is allowed to mount /var/log (for metrics)
+            if (
+                svcname == "reverse-proxy"
+                and volume["source"] == "/var/log"
+                and service["image"].startswith("ghcr.io/offspot/reverse-proxy:")
+            ):
+                continue
+            # other volumes are not accepted and thus removed
+            service["volumes"].remove(volume)
+
+        # remove cap_add for all ; will break captive portal but it's OK
+        if "cap_add" in service:
+            del service["cap_add"]
+
+        # only allow reverse-proxy to define ports ; ensure its 80/443
+        if not (
+            svcname == "reverse-proxy"
+            and service["image"].startswith("ghcr.io/offspot/reverse-proxy:")
+        ):
+            if "ports" in service:
+                del service["ports"]
+        else:
+            service["ports"] = ["80:80", "443:443"]
+
+        # only allow captive-portal to use set network_mode
+        if (
+            not (
+                svcname == "home-portal"
+                and service["image"].startswith("ghcr.io/offspot/captive-portal:")
+            )
+            and "network_mode" in service
+        ):
+            del service["network_mode"]
+
+        # allow none to be privileged ; breaks hwclock but it's OK
+        if "privileged" in service:
+            del service["privileged"]
+
+        # replace fqdn in all environment
+        for key, value in list(service.get("environment", {}).items()):
+            if key not in ("PROTECTED_SERVICES",):
+                service["environment"][key] = value.replace(orig_fqdn, FQDN)
+
+    # ATM we only support services
+    for key in ("networks", "volumes", "configs", "secrets"):
+        if compose.get(key):
+            del compose[key]
+
+    # pull all OCI images from oci_images
+    for entry in image_yaml.get("oci_images", []):
+        logger.info(f"> Pulling OCI Image {entry['ident']}")
+        docker_pull(entry["ident"])
+
+    # write new compose to partition
+    target_dir.joinpath("compose.yaml").write_text(yaml_dump(compose))
+
+    preapred_ok_path.touch()
+    return 0
+
+
+def entrypoint():
+    parser = argparse.ArgumentParser(
+        prog="demo-prepare", description="Prepare deployment from mounted image folder"
+    )
+
+    parser.add_argument(
+        dest="target_dir",
+        help="Path to the image's third partition, to prepare from",
+        default=str(TARGET_DIR),
+    )
+
+    args = parser.parse_args()
+    logger.setLevel(logging.DEBUG)
+
+    try:
+        sys.exit(prepare_image(target_dir=Path(args.target_dir).expanduser().resolve()))
+    except Exception as exc:
+        logger.exception(exc)
+        logger.critical(str(exc))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(entrypoint())

--- a/src/offspot_demo/prepare.py
+++ b/src/offspot_demo/prepare.py
@@ -1,2 +1,10 @@
+from pathlib import Path
+
+
 def entrypoint():
     print("Hello from prepare")
+
+
+def prepare_image(target_dir: Path) -> int:
+    print(f"prepare-image {target_dir=}")
+    return 1

--- a/src/offspot_demo/toggle.py
+++ b/src/offspot_demo/toggle.py
@@ -1,2 +1,6 @@
 def entrypoint():
     print("Hello from toggle")
+
+
+def toggle_demo(mode: str):
+    print(f"toggle-demo {mode=}")

--- a/src/offspot_demo/toggle.py
+++ b/src/offspot_demo/toggle.py
@@ -1,6 +1,25 @@
+from offspot_demo.constants import (
+    DOCKER_COMPOSE_IMAGE_PATH,
+    DOCKER_COMPOSE_SYMLINK_PATH,
+    Mode,
+)
+
+
 def entrypoint():
     print("Hello from toggle")
 
 
-def toggle_demo(mode: str):
+def toggle_demo(mode: Mode) -> int:
     print(f"toggle-demo {mode=}")
+    return 0
+
+
+def get_mode() -> Mode:
+    """modes currently active"""
+    # WARN: symlink doesn't tell whether compose is running or not
+    # and if it was launched with a different one
+    return (
+        Mode.IMAGE
+        if DOCKER_COMPOSE_SYMLINK_PATH.resolve() == DOCKER_COMPOSE_IMAGE_PATH
+        else Mode.MAINT
+    )

--- a/src/offspot_demo/utils/__init__.py
+++ b/src/offspot_demo/utils/__init__.py
@@ -15,3 +15,7 @@ def get_environ() -> dict[str, str]:
     environ.update({"LANG": "C", "LC_ALL": "C"})
     return environ
 
+
+def is_root() -> bool:
+    """whether running as root"""
+    return os.getuid() == 0

--- a/src/offspot_demo/utils/__init__.py
+++ b/src/offspot_demo/utils/__init__.py
@@ -1,5 +1,12 @@
 import os
 
+from offspot_demo.constants import logger
+
+
+def fail(message: str = "An error occured", code: int = 1) -> int:
+    """ shortcut to log an error message and return an error code"""
+    logger.error(message)
+    return code
 
 def get_environ() -> dict[str, str]:
     """current environment variable with langs set to C to control cli output"""

--- a/src/offspot_demo/utils/__init__.py
+++ b/src/offspot_demo/utils/__init__.py
@@ -1,0 +1,8 @@
+import os
+
+
+def get_environ() -> dict[str, str]:
+    """current environment variable with langs set to C to control cli output"""
+    environ = os.environ.copy()
+    environ.update({"LANG": "C", "LC_ALL": "C"})
+    return environ

--- a/src/offspot_demo/utils/__init__.py
+++ b/src/offspot_demo/utils/__init__.py
@@ -4,12 +4,14 @@ from offspot_demo.constants import logger
 
 
 def fail(message: str = "An error occured", code: int = 1) -> int:
-    """ shortcut to log an error message and return an error code"""
+    """shortcut to log an error message and return an error code"""
     logger.error(message)
     return code
+
 
 def get_environ() -> dict[str, str]:
     """current environment variable with langs set to C to control cli output"""
     environ = os.environ.copy()
     environ.update({"LANG": "C", "LC_ALL": "C"})
     return environ
+

--- a/src/offspot_demo/utils/image.py
+++ b/src/offspot_demo/utils/image.py
@@ -1,0 +1,178 @@
+import json
+import logging
+import os
+import pathlib
+import subprocess
+
+logger = logging.getLogger()
+
+# /!\ need to retrieve debug setting
+only_on_debug: bool = True
+
+
+def flush_writes():
+    """call sync to ensure all writes are commited to disks"""
+
+    os.sync()
+    subprocess.run(
+        ["/usr/bin/env", "sync", "-f"],
+        check=True,
+        capture_output=only_on_debug,
+        text=True,
+        env=get_environ(),
+    )
+
+
+def get_environ() -> dict[str, str]:
+    """current environment variable with langs set to C to control cli output"""
+    environ = os.environ.copy()
+    environ.update({"LANG": "C", "LC_ALL": "C"})
+    return environ
+
+
+def get_loopdev() -> str:
+    """free loop-device path ready to ease"""
+    return subprocess.run(
+        ["/usr/bin/env", "losetup", "-f"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=get_environ(),
+    ).stdout.strip()
+
+
+def get_losetup() -> list[dict[str, str | int]]:
+    """list of devices returned by losetup from, JSON output"""
+    return json.loads(
+        subprocess.run(
+            ["/usr/bin/env", "losetup", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=get_environ(),
+        ).stdout.strip()
+    )["loopdevices"]
+
+
+def is_loopdev_free(loop_dev: str):
+    """whether a loop-device (/dev/loopX) is not already attached"""
+    return loop_dev not in [device["name"] for device in get_losetup()]
+
+
+def get_loopdev_used_by(image_path: pathlib.Path) -> str:
+    """which loop_device an image file is currently attached to (if attached)"""
+    for device in get_losetup():
+        if device["back-file"] == str(image_path.resolve()):
+            return str(device["name"])
+
+    return ""
+
+
+def get_loop_name(loop_dev: str) -> str:
+    """name of loop from loop_dev (/dev/loopX -> loopX)"""
+    return str(pathlib.Path(loop_dev).relative_to(pathlib.Path("/dev")))
+
+
+def create_block_special_device(dev_path: str, major: int, minor: int):
+    """create a special block device (for partitions, inside docker)"""
+    logger.debug(f"Create mknod for {dev_path} with {major=} {minor=}")
+    subprocess.run(
+        ["/usr/bin/env", "mknod", dev_path, "b", str(major), str(minor)],
+        check=True,
+        capture_output=only_on_debug,
+        text=True,
+        env=get_environ(),
+    )
+
+
+def attach_to_device(img_fpath: pathlib.Path, loop_dev: str):
+    """attach a device image to a loop-device"""
+    subprocess.run(
+        ["/usr/bin/env", "losetup", "--partscan", loop_dev, str(img_fpath)],
+        check=True,
+        capture_output=only_on_debug,
+        text=True,
+        env=get_environ(),
+    )
+
+    # create nodes for partitions if not present (typically when run in docker)
+    if not pathlib.Path(f"{loop_dev}p1").exists():
+        logger.debug(f"Missing {loop_dev}p1 on fs")
+        loop_name = get_loop_name(loop_dev)
+        loop_block_dir = pathlib.Path("/sys/block/") / loop_name
+
+        if not loop_block_dir.exists():
+            raise OSError(f"{loop_block_dir} does not exists")
+        for part_dev_file in loop_block_dir.rglob(f"{loop_name}p*/dev"):
+            part_path = pathlib.Path(loop_dev).with_name(part_dev_file.parent.name)
+            major, minor = part_dev_file.read_text().strip().split(":", 1)
+            create_block_special_device(
+                dev_path=str(part_path), major=int(major), minor=int(minor)
+            )
+    else:
+        logger.debug(f"Found {loop_dev}p1 on fs")
+
+
+def detach_device(loop_dev: str, *, failsafe: bool = False) -> bool:
+    """whether detaching this loop-device succeeded"""
+    ps = subprocess.run(
+        ["/usr/bin/env", "losetup", "--detach", loop_dev],
+        check=not failsafe,
+        capture_output=only_on_debug,
+        text=True,
+        env=get_environ(),
+    )
+
+    # remove special block devices if still present (when in docker)
+    loop_path = pathlib.Path(loop_dev)
+    if loop_path.with_name(f"{loop_path.name}p1").exists():
+        logger.debug(f"{loop_dev}p1 not removed from fs")
+        for part_path in loop_path.parent.glob(f"{loop_path.name}p*"):
+            logger.debug(f"Unlinking {part_path}")
+            part_path.unlink(missing_ok=True)
+    else:
+        logger.debug(f"{loop_dev} properly removed from fs")
+
+    return ps.returncode == 0
+
+
+def mount_on(dev_path: str, mount_point: pathlib.Path, filesystem: str | None) -> bool:
+    """whether mounting device onto mount point succeeded"""
+    commands = ["/usr/bin/env", "mount"]
+    if filesystem:
+        commands += ["-t", filesystem]
+    commands += [dev_path, str(mount_point)]
+    return (
+        subprocess.run(
+            commands,
+            capture_output=only_on_debug,
+            text=True,
+            check=False,
+            env=get_environ(),
+        ).returncode
+        == 0
+    )
+
+
+def unmount(mount_point: pathlib.Path) -> bool:
+    """whether unmounting mount-point succeeded"""
+    flush_writes()
+    return (
+        subprocess.run(
+            ["/usr/bin/env", "umount", str(mount_point)],
+            capture_output=only_on_debug,
+            text=True,
+            check=False,
+            env=get_environ(),
+        ).returncode
+        == 0
+    )
+
+
+def is_mounted(mount_point: pathlib.Path) -> bool:
+    return (
+        subprocess.run(
+            ["/usr/bin/env", "mountpoint", "-q", str(mount_point)], check=False
+        ).returncode
+        == 0
+    )

--- a/src/offspot_demo/utils/image.py
+++ b/src/offspot_demo/utils/image.py
@@ -4,10 +4,8 @@ import os
 import pathlib
 import subprocess
 
-from offspot_demo.constants import get_logger
+from offspot_demo.constants import logger
 from offspot_demo.utils import get_environ
-
-logger = get_logger("deploy")  # reusing deploy logger to get its level
 
 
 def only_on_debug() -> bool:


### PR DESCRIPTION
- takes a single argument, being the URL of the image to download/deploy.
- optional, dev-only `--reuse-image` to test the rest without re-downloading each time
- Stub failing prepare_image for now
- utils.image module with all image-related operations: mounting/devices/etc
- Implemented as a long procedural function:
  - check URL
  - toggle to maint
  - unmount if mounted
  - detach device if attached
  - remove file if exists
  - prune docker
  - download image to file, validating checksum (taken from S3 headers)
  - attach image using new loop device
  - mount third partition
  - run prepare script (always failing for now, not impl.)
  - toggle to image
- Assumes specific maintenance label to prune docker images & containers
- Assumes image URL is on S3 host (or integrity is not checked)