### PR TITLE
Add watcher + toggle logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,5 @@ Kiwix is running a demo instance at http://demo.hotspot.kiwix.org
 - Use LXC containers to isolate from host and allow restoring snapshots frequently to prevent any attack from persisting
 - Use Apache Guacamole to isolate the hotpost HTTP service(s) as users would access a VNC-like rendering of it
 - Add an FAQ/doc for end-users (in GH for now)
+- Do not retry to deploy the same failing image over-and-over every "watcher interval" (15 minutes)
+- Implement a healthcheck endpoint (offspot services + demo watcher/deploy, with details like in imager-service https://imager.kiwix.org/health-check)

--- a/README.md
+++ b/README.md
@@ -56,18 +56,22 @@ This repository contains various scripts useful to setup / update the demo
 - check if target URL has changed
 - call `deploy-script` if it did, otherwise sleeps
 
-#### toggle module
+### toggle script
 
-Toggle from image to maint and vice-versa
+```sh
+toggle-compose [image|maint]
+```
 
 - check symlink for active one (and docker ps?)
 - down docker-compose
 - change symlink
 - up docker-compose
 
-#### deploy module
+### deploy script
 
-Deploy an image URL
+```sh
+deploy-demo-for http://xxxxx/xyz.img
+```
 
 - check URL
 - `toggle-compose maint`
@@ -80,9 +84,11 @@ Deploy an image URL
 - `toggle-compose image`
 
 
-#### prepare module
+### prepare script
 
-Prepare an image for local execution
+```sh
+prepare-image /demo/image.img
+```
 
 - setup loop-device
 - mount part3 onto `/data` (allows reusing all fs paths directly)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This repository contains various modules and scripts useful to setup / update th
 ### toggle module/script
 
 ```sh
-offspot-toggle [image|maint]
+demo-toggle [image|maint]
 ```
 
 - stop docker-compose
@@ -74,7 +74,7 @@ offspot-toggle [image|maint]
 ### deploy module/script
 
 ```sh
-deploy-demo-for http://xxxxx/xyz.img
+demo-deploy http://xxxxx/xyz.img
 ```
 
 - check URL
@@ -94,7 +94,7 @@ deploy-demo-for http://xxxxx/xyz.img
 ### prepare module/script
 
 ```sh
-offspot-prepare /data
+demo-prepare /data
 ```
 
 - check if already prepared via `/data/prepared.ok`

--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ Kiwix is running a demo instance at http://demo.hotspot.kiwix.org
 - node-like setup with bastion
 - docker install (comes with compose)
 - python install (3.12) + venv
+- few apt packages: mount coreutils aria2
+  - `apt install -y mount coreutils aria2`
 - this project installed somewhere
-  - pip install git+https://github.com/offspot/demo@main
+  - `pip install git+https://github.com/offspot/demo@main`
 
 ## Next
 

--- a/README.md
+++ b/README.md
@@ -56,22 +56,18 @@ This repository contains various scripts useful to setup / update the demo
 - check if target URL has changed
 - call `deploy-script` if it did, otherwise sleeps
 
-### toggle script
+#### toggle module
 
-```sh
-toggle-compose [image|maint]
-```
+Toggle from image to maint and vice-versa
 
 - check symlink for active one (and docker ps?)
 - down docker-compose
 - change symlink
 - up docker-compose
 
-### deploy script
+#### deploy module
 
-```sh
-deploy-demo-for http://xxxxx/xyz.img
-```
+Deploy an image URL
 
 - check URL
 - `toggle-compose maint`
@@ -84,11 +80,9 @@ deploy-demo-for http://xxxxx/xyz.img
 - `toggle-compose image`
 
 
-### prepare script
+#### prepare module
 
-```sh
-prepare-image /demo/image.img
-```
+Prepare an image for local execution
 
 - setup loop-device
 - mount part3 onto `/data` (allows reusing all fs paths directly)

--- a/contrib/environment
+++ b/contrib/environment
@@ -1,2 +1,14 @@
 # FQDN which will be used by the demo, e.g. demo.hotspot.kiwix.org
 OFFSPOT_DEMO_FQDN="demo.hostpot.kiwix.org"
+
+# URL of the Image to watch / deploy (either autoimage URL or email URL)
+OFFSPOT_IMAGE_URL="https://api.imager.kiwix.org/auto-images/offspot-demo/json"
+
+# Folder where everything will be deployed
+TARGET_DIR="/data"
+
+# Location of the image
+IMAGE_PATH="/demo/image.img"
+
+# OCI plateform to use (by default, offspot is linux/aarch64 but usually demo will run on linux/amd64)
+OCI_PLATFORM="linux/amd64"

--- a/install.sh
+++ b/install.sh
@@ -113,3 +113,10 @@ rm -f get-pip.py
 
 # check pip version
 pip --version
+
+# install aria2 static binary
+wget -O /tmp/aria2.zip https://github.com/abcfy2/aria2-static-build/releases/download/1.37.0/aria2-x86_64-linux-musl_libressl_static.zip \
+	&& unzip -d /tmp /tmp/aria2.zip \
+	&& mv /tmp/aria2c /usr/local/bin \
+	&& rm /tmp/aria2.zip \
+	&& aria2c -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ dev = [
 ]
 
 [project.scripts]
+demo-deploy = "offspot_demo.deploy:entrypoint"
+demo-prepare = "offspot_demo.prepare:entrypoint"
 demo-setup = "offspot_demo.setup:entrypoint"
+demo-toggle = "offspot_demo.toggle:entrypoint"
 demo-watcher = "offspot_demo.watcher:entrypoint"
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,8 +171,6 @@ ignore = [
   "S603",
   # Ignore complexity
   "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",
-  # Allow print command, at least for the PoC
-  "T201"
 ]
 unfixable = [
   # Don't touch unused imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,7 @@ dev = [
 ]
 
 [project.scripts]
-demo-deploy = "offspot_demo.deploy:entrypoint"
-demo-prepare = "offspot_demo.prepare:entrypoint"
 demo-setup = "offspot_demo.setup:entrypoint"
-demo-toggle = "offspot_demo.toggle:entrypoint"
 demo-watcher = "offspot_demo.watcher:entrypoint"
 
 [tool.hatch.version]

--- a/src/offspot_demo/constants.py
+++ b/src/offspot_demo/constants.py
@@ -8,7 +8,10 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from offspot_demo.__about__ import NAME
 
 OFFSPOT_IMAGE_ID = "offspot-demo"
-OFFSPOT_IMAGE_URL = f"https://api.imager.kiwix.org/auto-images/{OFFSPOT_IMAGE_ID}/json"
+OFFSPOT_IMAGE_URL = os.getenv(
+    "OFFSPOT_IMAGE_URL",
+    f"https://api.imager.kiwix.org/auto-images/{OFFSPOT_IMAGE_ID}/json",
+)
 TARGET_DIR = Path(os.getenv("TARGET_DIR", "/data"))
 IMAGE_PATH = Path(os.getenv("IMAGE_PATH", "/demo/image.img"))
 LAST_IMAGE_DEPLOYED_PATH = TARGET_DIR / "last_image"

--- a/src/offspot_demo/constants.py
+++ b/src/offspot_demo/constants.py
@@ -11,6 +11,7 @@ OFFSPOT_IMAGE_ID = "offspot-demo"
 OFFSPOT_IMAGE_URL = f"https://api.imager.kiwix.org/auto-images/{OFFSPOT_IMAGE_ID}/json"
 TARGET_DIR = Path(os.getenv("TARGET_DIR", "/data"))
 IMAGE_PATH = Path(os.getenv("IMAGE_PATH", "/demo/image.img"))
+LAST_IMAGE_DEPLOYED_PATH = TARGET_DIR / "last_image"
 
 FQDN = os.getenv("OFFSPOT_DEMO_FQDN", "demo.hostpot.kiwix.org")
 
@@ -20,10 +21,9 @@ DOCKER_COMPOSE_IMAGE_PATH = TARGET_DIR / "compose.yaml"
 DOCKER_COMPOSE_MAINT_PATH = SRC_PATH / "maint-compose" / "docker-compose.yml"
 DOCKER_COMPOSE_SYMLINK_PATH = Path("/etc/docker/compose.yaml")
 
+SYSTEMD_UNITS_PATH = Path("/etc/systemd/system/")
 SYSTEMD_OFFSPOT_UNIT_NAME = "demo-offspot"
-SYSTEMD_OFFSPOT_UNIT_PATH = Path(
-    f"/etc/systemd/system/{SYSTEMD_OFFSPOT_UNIT_NAME}.service"
-)
+SYSTEMD_WATCHER_UNIT_NAME = "demo-watcher"
 
 JINJA_ENV = Environment(
     loader=FileSystemLoader(Path(__file__).parent), autoescape=select_autoescape()
@@ -47,3 +47,6 @@ class Mode(enum.Enum):
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(NAME)
+
+# Default timeout of HTTP requests made by the scripts
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30

--- a/src/offspot_demo/deploy.py
+++ b/src/offspot_demo/deploy.py
@@ -5,11 +5,8 @@ Limitations:
 - Image must be Imager-service-created: have its data in a 3rd ext4 partition
 """
 
-import argparse
 import hashlib
 import http
-import logging
-import sys
 from contextlib import ExitStack
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -311,41 +308,3 @@ def unmount_detach_release() -> int:
 def set_maint_mode() -> int:
     """change mode to maintenance mode (used as cleanup)"""
     return toggle_demo(Mode.MAINT)
-
-
-def entrypoint():
-    parser = argparse.ArgumentParser(
-        prog="demo-deploy",
-        description="Deploy an offspot demo from an Image URL",
-        epilog="URL comes from either auto-image JSON "  # noqa: ISC003
-        + "or Imager Service email. "
-        + "https://org-kiwix-hotspot-cardshop-download.s3.us-west-1.wasabisys.com/"
-        + "xxxxx.img",
-    )
-
-    parser.add_argument(
-        "--reuse-image",
-        action="store_true",
-        dest="reuse_image",
-        default=False,
-        help="[dev] reuse already downloaded image instead of downloading",
-    )
-
-    parser.add_argument(
-        dest="url",
-        help="Imager Service-created Image URL",
-    )
-
-    args = parser.parse_args()
-    logger.setLevel(logging.DEBUG)
-
-    try:
-        sys.exit(deploy_url(url=args.url, reuse_image=args.reuse_image))
-    except Exception as exc:
-        logger.exception(exc)
-        logger.critical(str(exc))
-        sys.exit(1)
-
-
-if __name__ == "__main__":
-    sys.exit(entrypoint())

--- a/src/offspot_demo/deploy.py
+++ b/src/offspot_demo/deploy.py
@@ -5,8 +5,11 @@ Limitations:
 - Image must be Imager-service-created: have its data in a 3rd ext4 partition
 """
 
+import argparse
 import hashlib
 import http
+import logging
+import sys
 from contextlib import ExitStack
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -308,3 +311,41 @@ def unmount_detach_release() -> int:
 def set_maint_mode() -> int:
     """change mode to maintenance mode (used as cleanup)"""
     return toggle_demo(Mode.MAINT)
+
+
+def entrypoint():
+    parser = argparse.ArgumentParser(
+        prog="demo-deploy",
+        description="Deploy an offspot demo from an Image URL",
+        epilog="URL comes from either auto-image JSON "  # noqa: ISC003
+        + "or Imager Service email. "
+        + "https://org-kiwix-hotspot-cardshop-download.s3.us-west-1.wasabisys.com/"
+        + "xxxxx.img",
+    )
+
+    parser.add_argument(
+        "--reuse-image",
+        action="store_true",
+        dest="reuse_image",
+        default=False,
+        help="[dev] reuse already downloaded image instead of downloading",
+    )
+
+    parser.add_argument(
+        dest="url",
+        help="Imager Service-created Image URL",
+    )
+
+    args = parser.parse_args()
+    logger.setLevel(logging.DEBUG)
+
+    try:
+        sys.exit(deploy_url(url=args.url, reuse_image=args.reuse_image))
+    except Exception as exc:
+        logger.exception(exc)
+        logger.critical(str(exc))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(entrypoint())

--- a/src/offspot_demo/deploy.py
+++ b/src/offspot_demo/deploy.py
@@ -18,6 +18,7 @@ from typing import NamedTuple
 import requests
 
 from offspot_demo.constants import (
+    DEFAULT_HTTP_TIMEOUT_SECONDS,
     DOCKER_LABEL_MAINT,
     IMAGE_PATH,
     TARGET_DIR,
@@ -43,7 +44,7 @@ ONE_MIB = 2**20
 
 def is_url_correct(url: str) -> bool:
     """whether URL is reachable"""
-    with requests.get(url, timeout=5, stream=True) as resp:
+    with requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS, stream=True) as resp:
         return resp.status_code == http.HTTPStatus.OK
 
 
@@ -116,7 +117,7 @@ def get_checksum_from(url: str) -> S3CompatibleETag:
     Should the URL not return an ETag or Content-Length, it is assumed to not
     have a checksum."""
 
-    with requests.get(url, timeout=5, stream=True) as resp:
+    with requests.get(url, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS, stream=True) as resp:
         size = resp.headers.get("Content-Length")
         etag = resp.headers.get("ETag", "").replace('"', "").replace("'", "")
     if not size or not etag:

--- a/src/offspot_demo/maint-compose/Dockerfile
+++ b/src/offspot_demo/maint-compose/Dockerfile
@@ -1,4 +1,6 @@
 FROM caddy:2.6.1-alpine
 
+LABEL maintenance=true
+
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY index.html /app/index.html

--- a/src/offspot_demo/prepare.py
+++ b/src/offspot_demo/prepare.py
@@ -1,3 +1,6 @@
+import argparse
+import logging
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +13,7 @@ except ImportError:
     # we don't NEED cython ext but it's faster so use it if avail.
     from yaml import Dumper, SafeLoader
 
-from offspot_demo.constants import FQDN, OCI_PLATFORM, logger
+from offspot_demo.constants import FQDN, OCI_PLATFORM, TARGET_DIR, logger
 from offspot_demo.utils import fail, is_root
 from offspot_demo.utils.process import run_command
 
@@ -173,3 +176,29 @@ def prepare_image(target_dir: Path) -> int:
 
     preapred_ok_path.touch()
     return 0
+
+
+def entrypoint():
+    parser = argparse.ArgumentParser(
+        prog="demo-prepare", description="Prepare deployment from mounted image folder"
+    )
+
+    parser.add_argument(
+        dest="target_dir",
+        help="Path to the image's third partition, to prepare from",
+        default=str(TARGET_DIR),
+    )
+
+    args = parser.parse_args()
+    logger.setLevel(logging.DEBUG)
+
+    try:
+        sys.exit(prepare_image(target_dir=Path(args.target_dir).expanduser().resolve()))
+    except Exception as exc:
+        logger.exception(exc)
+        logger.critical(str(exc))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(entrypoint())

--- a/src/offspot_demo/prepare.py
+++ b/src/offspot_demo/prepare.py
@@ -1,6 +1,3 @@
-import argparse
-import logging
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -13,7 +10,7 @@ except ImportError:
     # we don't NEED cython ext but it's faster so use it if avail.
     from yaml import Dumper, SafeLoader
 
-from offspot_demo.constants import FQDN, OCI_PLATFORM, TARGET_DIR, logger
+from offspot_demo.constants import FQDN, OCI_PLATFORM, logger
 from offspot_demo.utils import fail, is_root
 from offspot_demo.utils.process import run_command
 
@@ -176,29 +173,3 @@ def prepare_image(target_dir: Path) -> int:
 
     preapred_ok_path.touch()
     return 0
-
-
-def entrypoint():
-    parser = argparse.ArgumentParser(
-        prog="demo-prepare", description="Prepare deployment from mounted image folder"
-    )
-
-    parser.add_argument(
-        dest="target_dir",
-        help="Path to the image's third partition, to prepare from",
-        default=str(TARGET_DIR),
-    )
-
-    args = parser.parse_args()
-    logger.setLevel(logging.DEBUG)
-
-    try:
-        sys.exit(prepare_image(target_dir=Path(args.target_dir).expanduser().resolve()))
-    except Exception as exc:
-        logger.exception(exc)
-        logger.critical(str(exc))
-        sys.exit(1)
-
-
-if __name__ == "__main__":
-    sys.exit(entrypoint())

--- a/src/offspot_demo/systemd-unit/demo-offspot.service
+++ b/src/offspot_demo/systemd-unit/demo-offspot.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=offspot-demo
+Description=demo-offspot
 Requires=docker.service
 After=docker.service
 

--- a/src/offspot_demo/systemd-unit/demo-watcher.service
+++ b/src/offspot_demo/systemd-unit/demo-watcher.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=demo-watcher
+
+[Service]
+User=root
+ExecStart=/root/env/bin/demo-watcher
+EnvironmentFile=/etc/demo/environment

--- a/src/offspot_demo/systemd-unit/demo-watcher.timer
+++ b/src/offspot_demo/systemd-unit/demo-watcher.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=demo-watcher
+
+[Timer]
+OnBootSec=5min
+# we use OnUnitInactiveSec to ensure we do not have two concurrent deployment AND
+# we pause at least 15 minutes between every deployment (no need to run many deployment
+# in a short timeframe except for maintenance reason where it can be done manually)
+OnUnitInactiveSec=15min
+
+[Install]
+WantedBy=multi-user.target

--- a/src/offspot_demo/toggle.py
+++ b/src/offspot_demo/toggle.py
@@ -2,15 +2,16 @@ from offspot_demo.constants import (
     DOCKER_COMPOSE_IMAGE_PATH,
     DOCKER_COMPOSE_SYMLINK_PATH,
     Mode,
+    logger,
 )
 
 
 def entrypoint():
-    print("Hello from toggle")
+    logger.info("Hello from toggle")
 
 
 def toggle_demo(mode: Mode) -> int:
-    print(f"toggle-demo {mode=}")
+    logger.info(f"toggle-demo {mode=}")
     return 0
 
 

--- a/src/offspot_demo/toggle.py
+++ b/src/offspot_demo/toggle.py
@@ -1,3 +1,6 @@
+import argparse
+import logging
+import sys
 from time import sleep
 
 from offspot_demo.constants import (
@@ -71,3 +74,37 @@ def get_mode() -> Mode:
         if DOCKER_COMPOSE_SYMLINK_PATH.resolve() == DOCKER_COMPOSE_IMAGE_PATH
         else Mode.MAINT
     )
+
+
+def entrypoint():
+    parser = argparse.ArgumentParser(
+        prog="demo-toggle", description="Toggle between maint and image modes"
+    )
+
+    parser.add_argument(
+        dest="mode",
+        help="New target mode, either maint or image",
+        default="maint",
+    )
+
+    args = parser.parse_args()
+    logger.setLevel(logging.DEBUG)
+
+    try:
+        if args.mode == "image":
+            mode = Mode.IMAGE
+        elif args.mode == "maint":
+            mode = Mode.MAINT
+        else:
+            raise Exception(
+                f"Unsupported mode: {args.mode}, must be either image or maint"
+            )
+        sys.exit(toggle_demo(mode=mode))
+    except Exception as exc:
+        logger.exception(exc)
+        logger.critical(str(exc))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(entrypoint())

--- a/src/offspot_demo/toggle.py
+++ b/src/offspot_demo/toggle.py
@@ -40,7 +40,6 @@ def toggle_demo(mode: Mode) -> int:
         DOCKER_COMPOSE_SYMLINK_PATH.symlink_to(DOCKER_COMPOSE_MAINT_PATH)
 
     logger.info("Starting systemd unit")
-    start_systemd_unit(systemd_unit_fullname)
 
     logger.info(
         f"Sleeping {STARTUP_DURATION} seconds to check system status still ok after a"
@@ -85,20 +84,14 @@ def entrypoint():
         dest="mode",
         help="New target mode, either maint or image",
         default="maint",
+        choices=[m.lower() for m  in Mode.__members__.keys()],
     )
 
     args = parser.parse_args()
     logger.setLevel(logging.DEBUG)
 
     try:
-        if args.mode == "image":
-            mode = Mode.IMAGE
-        elif args.mode == "maint":
-            mode = Mode.MAINT
-        else:
-            raise Exception(
-                f"Unsupported mode: {args.mode}, must be either image or maint"
-            )
+        mode = Mode[args.mode.upper()]
         sys.exit(toggle_demo(mode=mode))
     except Exception as exc:
         logger.exception(exc)

--- a/src/offspot_demo/toggle.py
+++ b/src/offspot_demo/toggle.py
@@ -18,7 +18,6 @@ from offspot_demo.utils.systemd import (
     SystemdNotLoadedError,
     SystemdNotRunningError,
     check_systemd_service,
-    start_systemd_unit,
     stop_systemd_unit,
 )
 
@@ -84,7 +83,7 @@ def entrypoint():
         dest="mode",
         help="New target mode, either maint or image",
         default="maint",
-        choices=[m.lower() for m  in Mode.__members__.keys()],
+        choices=[m.lower() for m in Mode.__members__.keys()],
     )
 
     args = parser.parse_args()

--- a/src/offspot_demo/utils/process.py
+++ b/src/offspot_demo/utils/process.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
 
+from offspot_demo.constants import logger
+
 
 def run_command(
     command: list[str],
@@ -24,9 +26,10 @@ def run_command(
         check=False,
     )
     if process.returncode not in ok_return_codes:
-        print(f"Running command failed with code {process.returncode}")
-        print(f"Command was: {command}")
-        print("Stdout/Stderr is:")
-        print(process.stdout)
+        logger.error(
+            f"Running command failed with code {process.returncode}\n"
+            f"Command was: {command}\n"
+            f"Stdout/Stderr is:\n{process.stdout}"
+        )
         sys.exit(1)
     return process

--- a/src/offspot_demo/utils/systemd.py
+++ b/src/offspot_demo/utils/systemd.py
@@ -1,0 +1,85 @@
+import subprocess
+
+from offspot_demo.utils.process import run_command
+
+
+class SystemdError(Exception):
+
+    def __init__(self, stdout: str, *args: object) -> None:
+        self.stdout = stdout
+        super().__init__(*args)
+
+
+class SystemdNotRunningError(SystemdError):
+    pass
+
+
+class SystemdNotWaitingError(SystemdError):
+    pass
+
+
+class SystemdNotEnabledError(SystemdError):
+    pass
+
+
+class SystemdNotLoadedError(SystemdError):
+    pass
+
+
+def check_systemd_service(
+    unit_fullname: str,
+    *,
+    check_running: bool = False,
+    check_waiting: bool = False,
+    check_enabled: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Check status of the systemd unit
+
+    By default, check at least that the unit is loaded properly (i.e. parsing is ok),
+    otherwise a SystemdNotLoadedError is raised.
+    If check_running is True, it also checks that the unit is running, otherwise a
+    SystemdNotRunningError is raiase
+    If check_enabled is True, it also checks that the unit is enabled, otherwise a
+    SystemdNotEnabledError is raiase
+    If check_waiting is True, it also checks that the unit is waiting, otherwise a
+    SystemdNotWaitingError is raiase
+    """
+    process = run_command(
+        [
+            "systemctl",
+            "status",
+            "--no-pager",
+            unit_fullname,
+        ],
+        ok_return_codes=[0, 3],
+    )
+    if "Loaded: loaded" not in process.stdout:
+        raise SystemdNotLoadedError(stdout=process.stdout)
+    if check_running and "Active: active (running)" not in process.stdout:
+        raise SystemdNotRunningError(stdout=process.stdout)
+    if check_waiting and "Active: active (waiting)" not in process.stdout:
+        raise SystemdNotWaitingError(stdout=process.stdout)
+    if check_enabled and "; enabled; " not in process.stdout:
+        raise SystemdNotWaitingError(stdout=process.stdout)
+    return process
+
+
+def start_systemd_unit(unit_fullname: str):
+    """Starts a systemd unit, based on its fullname e.g. my-timer.timer"""
+
+    run_command(["systemctl", "start", "--no-pager", unit_fullname])
+
+
+def stop_systemd_unit(unit_fullname: str):
+    """Stops a systemd unit, based on its fullname e.g. my-timer.timer"""
+
+    # return code 5 is allowed since the service might not be started yet
+    run_command(
+        ["systemctl", "stop", "--no-pager", unit_fullname], ok_return_codes=[0, 5]
+    )
+
+
+def enable_systemd_unit(unit_fullname: str):
+    """Enables a systemd unit, based on its fullname e.g. my-timer.timer"""
+
+    run_command(["systemctl", "stop", "--no-pager", unit_fullname])

--- a/src/offspot_demo/utils/systemd.py
+++ b/src/offspot_demo/utils/systemd.py
@@ -11,19 +11,19 @@ class SystemdError(Exception):
 
 
 class SystemdNotRunningError(SystemdError):
-    pass
+    return_code = 3
 
 
 class SystemdNotWaitingError(SystemdError):
-    pass
+    return_code = 4
 
 
 class SystemdNotEnabledError(SystemdError):
-    pass
+    return_code = 5
 
 
 class SystemdNotLoadedError(SystemdError):
-    pass
+    return_code = 2
 
 
 def check_systemd_service(
@@ -35,14 +35,20 @@ def check_systemd_service(
 ) -> subprocess.CompletedProcess[str]:
     """Check status of the systemd unit
 
-    By default, check at least that the unit is loaded properly (i.e. parsing is ok),
-    otherwise a SystemdNotLoadedError is raised.
-    If check_running is True, it also checks that the unit is running, otherwise a
-    SystemdNotRunningError is raiase
-    If check_enabled is True, it also checks that the unit is enabled, otherwise a
-    SystemdNotEnabledError is raiase
-    If check_waiting is True, it also checks that the unit is waiting, otherwise a
-    SystemdNotWaitingError is raiase
+    The minimal check consists in ensuring that the systemd unit is properly loaded (no
+    parsing issue, no unknown parameter, ...)
+
+    Parameters:
+        unit_fullname: full name of the systemd unit to check (e.g. my-timer.timer)
+        check_running: also check that systemd unit is running
+        check_waiting: also check that systemd unit is waiting (for timers typically)
+        check_enabled: also check that systemd unit is enabled
+
+    Raises:
+        SystemdNotLoadedError: if unit is not properly loaded
+        SystemdNotRunningError: if unit is not running ; when using check_running
+        SystemdNotEnabledError: if unit is not enabled ; when using check_enabled
+        SystemdNotWaitingError: if unit is not waiting ; when using check_waiting
     """
     process = run_command(
         [

--- a/src/offspot_demo/watcher.py
+++ b/src/offspot_demo/watcher.py
@@ -22,7 +22,7 @@ def get_new_deploy_url() -> str | None:
 
     Returns None otherwise.
     """
-    if not (LAST_IMAGE_DEPLOYED_PATH).exists():
+    if not LAST_IMAGE_DEPLOYED_PATH.exists():
         last_image_fetched = None
     else:
         last_image_fetched = LAST_IMAGE_DEPLOYED_PATH.read_text()

--- a/src/offspot_demo/watcher.py
+++ b/src/offspot_demo/watcher.py
@@ -11,6 +11,7 @@ from offspot_demo.constants import (
     logger,
 )
 from offspot_demo.deploy import deploy_url
+from offspot_demo.utils import fail, is_root
 
 
 def get_new_deploy_url() -> str | None:
@@ -41,6 +42,8 @@ def get_new_deploy_url() -> str | None:
 
 def check_and_deploy():
     """Check if a new image has to be deployed, and deploy it"""
+    if not is_root():
+        return fail("must be root", 1)
     # create folder to store LAST_IMAGE_DEPLOYED file
     LAST_IMAGE_DEPLOYED_PATH.parent.mkdir(parents=True, exist_ok=True)
     logger.info("Checking for new image")

--- a/src/offspot_demo/watcher.py
+++ b/src/offspot_demo/watcher.py
@@ -1,2 +1,84 @@
+import argparse
+import logging
+import sys
+
+import requests
+
+from offspot_demo.constants import (
+    DEFAULT_HTTP_TIMEOUT_SECONDS,
+    LAST_IMAGE_DEPLOYED_PATH,
+    OFFSPOT_IMAGE_URL,
+    logger,
+)
+from offspot_demo.deploy import deploy_url
+
+
+def get_new_deploy_url() -> str | None:
+    """Check if deploy image has changed
+
+    Returns the current image URL if it has changed (or has never been successfully
+    deployed).
+
+    Returns None otherwise.
+    """
+    if not (LAST_IMAGE_DEPLOYED_PATH).exists():
+        last_image_fetched = None
+    else:
+        last_image_fetched = LAST_IMAGE_DEPLOYED_PATH.read_text()
+
+    response = requests.get(OFFSPOT_IMAGE_URL, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS)
+    response.raise_for_status()
+    response_json = response.json()
+    if "http_url" not in response_json or not response_json["http_url"]:
+        logger.warning(f"'http_url' not found in response from {OFFSPOT_IMAGE_URL}")
+        logger.debug(response.content)
+        raise Exception("Unexpected response from image provider")
+    if last_image_fetched != response_json["http_url"]:
+        return response_json["http_url"]
+    else:
+        return None
+
+
+def check_and_deploy():
+    """Check if a new image has to be deployed, and deploy it"""
+    # create folder to store LAST_IMAGE_DEPLOYED file
+    LAST_IMAGE_DEPLOYED_PATH.parent.mkdir(parents=True, exist_ok=True)
+    logger.info("Checking for new image")
+    new_deploy_url = get_new_deploy_url()
+    if not new_deploy_url:
+        logger.info("Image has not been updated")
+        return
+    logger.info(f"Starting demo deployment with {new_deploy_url}")
+    deploy_url(url=new_deploy_url, reuse_image=False)
+    logger.info("Deploy OK, persisting last image url")
+    LAST_IMAGE_DEPLOYED_PATH.write_text(new_deploy_url)
+
+
 def entrypoint():
-    print("Hello from watcher")
+    parser = argparse.ArgumentParser(
+        prog="demo-watcher",
+        description="Watch an offspot demo Image URL updates and trigger deployment",
+    )
+
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        dest="debug",
+        default=False,
+        help="Activate debug logs",
+    )
+
+    args = parser.parse_args()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+
+    try:
+        sys.exit(check_and_deploy())
+    except Exception as exc:
+        logger.exception(exc)
+        logger.critical(str(exc))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(entrypoint())


### PR DESCRIPTION
- Add logic to watch an online URL and trigger deployment when changed
- Add logic to toggle between maintenance and image modes
- Keep only two entrypoints, since other are not needed except in development (but not used much in fact)