### PR TITLE
Stop aria2c on download completion

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,3 +120,6 @@ wget -O /tmp/aria2.zip https://github.com/abcfy2/aria2-static-build/releases/dow
 	&& mv /tmp/aria2c /usr/local/bin \
 	&& rm /tmp/aria2.zip \
 	&& aria2c -v
+
+# script to “gently” terminate aria2c
+printf '#!/bin/sh\nkill -HUP $(pgrep aria2c)\n' > /usr/local/bin/stop_aria2c_processes && chmod +x /usr/local/bin/stop_aria2c_processes

--- a/src/offspot_demo/deploy.py
+++ b/src/offspot_demo/deploy.py
@@ -172,6 +172,8 @@ def download_file_into(url: str, dest: Path, digest: S3CompatibleETag) -> int:
             "--out",
             "image.img",
             "--enable-rpc",
+            "--on-download-complete=stop_aria2c_processes",
+            "--on-download-error=stop_aria2c_processes",
         ]
         # single part checksum, let aria2 handle checksum validation
         if digest.is_singlepart:


### PR DESCRIPTION
With commit f3c352a, we are now enabling aria2c's RPC interface which allows us to query it to get download statuses (using aria2p cli tool for instance). This RPC option (although it's not mentioned in the doc) changes the behavior of aria2c and turns it into a daemon, even if it was launched with a single download. It thus doesn't stop anymore at the end of said download.

This introduce two changes:
- a script that terminates all aria2c processes. It uses SIGHUP as aria2c handles it as a request to terminate, ensuring exit code corresponds to aria2c's status.
- using said script as download-complete and download-error hooks